### PR TITLE
test: add unit tests for AuthUseCase, JwtTokenDTO, and User classes

### DIFF
--- a/domain/model/src/test/java/co/com/pragma/model/role/RoleTest.java
+++ b/domain/model/src/test/java/co/com/pragma/model/role/RoleTest.java
@@ -1,0 +1,79 @@
+package co.com.pragma.model.role;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RoleTest {
+
+    @Test
+    @DisplayName("Builder crea Role con todos los campos")
+    void builderCreatesRole() {
+        UUID id = UUID.randomUUID();
+
+        Role role = Role.builder()
+                .roleId(id)
+                .name("ADMIN")
+                .description("Admin role")
+                .build();
+
+        assertThat(role.getRoleId()).isEqualTo(id);
+        assertThat(role.getName()).isEqualTo("ADMIN");
+        assertThat(role.getDescription()).isEqualTo("Admin role");
+    }
+
+    @Test
+    @DisplayName("No-args + setters funcionan y getters devuelven valores")
+    void noArgsAndSetters() {
+        Role role = new Role();
+        UUID id = UUID.randomUUID();
+
+        role.setRoleId(id);
+        role.setName("USER");
+        role.setDescription("Standard user");
+
+        assertThat(role.getRoleId()).isEqualTo(id);
+        assertThat(role.getName()).isEqualTo("USER");
+        assertThat(role.getDescription()).isEqualTo("Standard user");
+    }
+
+    @Test
+    @DisplayName("toBuilder permite clonar y cambiar un campo")
+    void toBuilderCloneAndModify() {
+        Role original = Role.builder()
+                .roleId(UUID.randomUUID())
+                .name("MANAGER")
+                .description("Manages stuff")
+                .build();
+
+        Role changed = original.toBuilder().name("LEAD").build();
+
+        assertThat(changed.getName()).isEqualTo("LEAD");
+        assertThat(changed.getDescription()).isEqualTo(original.getDescription());
+        assertThat(changed.getRoleId()).isEqualTo(original.getRoleId());
+        assertThat(changed).isNotSameAs(original);
+    }
+
+    @Test
+    @DisplayName("equals/hashCode por @Data (mismos campos => iguales)")
+    void equalsAndHashCode() {
+        UUID id = UUID.randomUUID();
+
+        Role a = Role.builder().roleId(id).name("QA").description("Quality").build();
+        Role b = Role.builder().roleId(id).name("QA").description("Quality").build();
+
+        assertThat(a).isEqualTo(b);
+        assertThat(a).hasSameHashCodeAs(b);
+    }
+
+    @Test
+    @DisplayName("toString incluye campos relevantes")
+    void toStringContainsFields() {
+        Role role = Role.builder().name("DEV").description("Developer").build();
+        assertThat(role.toString()).contains("DEV").contains("Developer");
+    }
+
+}

--- a/domain/model/src/test/java/co/com/pragma/model/role/error/RoleErrorCodeTest.java
+++ b/domain/model/src/test/java/co/com/pragma/model/role/error/RoleErrorCodeTest.java
@@ -1,0 +1,45 @@
+package co.com.pragma.model.role.error;
+
+import co.com.pragma.model.shared.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.text.MessageFormat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RoleErrorCodeTest {
+
+    @Test
+    @DisplayName("ROLE_NOT_FOUND expone metadatos correctos")
+    void roleNotFound_metadata() {
+        RoleErrorCode code = RoleErrorCode.ROLE_NOT_FOUND;
+
+        assertThat(code.getAppCode()).isEqualTo("ROL_001");
+        assertThat(code.getHttpCode()).isEqualTo(404);
+        assertThat(code.getMessage()).isEqualTo("Role not found with id {0}");
+    }
+
+    @Test
+    @DisplayName("Formato de mensaje con parámetro {0}")
+    void messageFormatting() {
+        String formatted = MessageFormat.format(RoleErrorCode.ROLE_NOT_FOUND.getMessage(), "123");
+        assertThat(formatted).isEqualTo("Role not found with id 123");
+    }
+
+    @Test
+    @DisplayName("values() y valueOf() funcionan y solo hay una constante")
+    void valuesAndValueOf() {
+        RoleErrorCode[] values = RoleErrorCode.values();
+        assertThat(values).hasSize(1);
+        assertThat(RoleErrorCode.valueOf("ROLE_NOT_FOUND"))
+                .isSameAs(RoleErrorCode.ROLE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("El enum implementa ErrorCode")
+    void implementsErrorCode() {
+        assertThat(RoleErrorCode.ROLE_NOT_FOUND).isInstanceOf(ErrorCode.class);
+    }
+
+}

--- a/domain/model/src/test/java/co/com/pragma/model/user/UserTest.java
+++ b/domain/model/src/test/java/co/com/pragma/model/user/UserTest.java
@@ -7,13 +7,14 @@ import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class UserTest {
+class UserTest {
 
     @Test
     @DisplayName("NoArgsConstructor + setters + getters should work")
     void noArgs_setters_getters() {
         User u = new User();
         UUID id = UUID.randomUUID();
+        UUID roleId = UUID.randomUUID();
 
         u.setUserId(id);
         u.setFirstName("Juan");
@@ -22,6 +23,8 @@ public class UserTest {
         u.setId("123");
         u.setPhoneNumber("555-1234");
         u.setBaseSalary(5_000_000d);
+        u.setPassword("password");
+        u.setRoleId(roleId);
 
         assertThat(u.getUserId()).isEqualTo(id);
         assertThat(u.getFirstName()).isEqualTo("Juan");
@@ -30,13 +33,20 @@ public class UserTest {
         assertThat(u.getId()).isEqualTo("123");
         assertThat(u.getPhoneNumber()).isEqualTo("555-1234");
         assertThat(u.getBaseSalary()).isEqualTo(5_000_000d);
+        assertThat(u.getPassword()).isEqualTo("password");
+        assertThat(u.getRoleId()).isEqualTo(roleId);
     }
 
     @Test
     @DisplayName("AllArgsConstructor should assign all fields")
     void allArgsConstructor() {
         UUID id = UUID.randomUUID();
-        User u = new User(id, "Juan", "Perez", "jp@mail.com", "123", "555-1234", 1_000_000d, "password");
+        UUID roleId = UUID.randomUUID();
+
+        User u = new User(
+                id, "Juan", "Perez", "jp@mail.com",
+                "123", "555-1234", 1_000_000d, "password", roleId
+        );
 
         assertThat(u.getUserId()).isEqualTo(id);
         assertThat(u.getFirstName()).isEqualTo("Juan");
@@ -45,21 +55,30 @@ public class UserTest {
         assertThat(u.getId()).isEqualTo("123");
         assertThat(u.getPhoneNumber()).isEqualTo("555-1234");
         assertThat(u.getBaseSalary()).isEqualTo(1_000_000d);
+        assertThat(u.getPassword()).isEqualTo("password");
+        assertThat(u.getRoleId()).isEqualTo(roleId);
     }
 
     @Test
     @DisplayName("equals/hashCode should consider all fields (Lombok @Data)")
     void equals_hashCode() {
         UUID id = UUID.randomUUID();
-        User a = new User(id, "Juan", "Perez", "jp@mail.com", "123", "555-1234", 1_000_000d, "password");
-        User b = new User(id, "Juan", "Perez", "jp@mail.com", "123", "555-1234", 1_000_000d, "password");
-        User c = new User(id, "Juan", "Perez", "otro@mail.com", "123", "555-1234", 1_000_000d, "password");
+        UUID roleId = UUID.randomUUID();
+        UUID otherRole = UUID.randomUUID();
+
+        User a = new User(id, "Juan", "Perez", "jp@mail.com", "123", "555-1234", 1_000_000d, "password", roleId);
+        User b = new User(id, "Juan", "Perez", "jp@mail.com", "123", "555-1234", 1_000_000d, "password", roleId);
+        User c = new User(id, "Juan", "Perez", "otro@mail.com", "123", "555-1234", 1_000_000d, "password", roleId);
+        User d = new User(id, "Juan", "Perez", "jp@mail.com", "123", "555-1234", 1_000_000d, "password", otherRole);
 
         assertThat(a).isEqualTo(b);
         assertThat(a).hasSameHashCodeAs(b);
 
         assertThat(a).isNotEqualTo(c);
         assertThat(a.hashCode()).isNotEqualTo(c.hashCode());
+
+        assertThat(a).isNotEqualTo(d);
+        assertThat(a.hashCode()).isNotEqualTo(d.hashCode());
     }
 
     @Test
@@ -70,5 +89,4 @@ public class UserTest {
         assertThat(s).isNotNull().isNotBlank();
         assertThat(s).contains("User");
     }
-
 }

--- a/domain/model/src/test/java/co/com/pragma/model/user/dto/request/LoginModelDTOTest.java
+++ b/domain/model/src/test/java/co/com/pragma/model/user/dto/request/LoginModelDTOTest.java
@@ -1,0 +1,24 @@
+package co.com.pragma.model.user.dto.request;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoginModelDTOTest {
+
+    @Test
+    @DisplayName("Record expone campos y equals/hashCode por valor")
+    void basics() {
+        LoginModelDTO a = new LoginModelDTO("user@mail.com", "secret");
+        LoginModelDTO b = new LoginModelDTO("user@mail.com", "secret");
+
+        assertThat(a.email()).isEqualTo("user@mail.com");
+        assertThat(a.password()).isEqualTo("secret");
+
+        assertThat(a).isEqualTo(b);
+        assertThat(a).hasSameHashCodeAs(b);
+        assertThat(a.toString()).contains("user@mail.com");
+    }
+
+}

--- a/domain/model/src/test/java/co/com/pragma/model/user/dto/response/JwtTokenDTOTest.java
+++ b/domain/model/src/test/java/co/com/pragma/model/user/dto/response/JwtTokenDTOTest.java
@@ -1,0 +1,22 @@
+package co.com.pragma.model.user.dto.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenDTOTest {
+
+    @Test
+    @DisplayName("Record expone token y equals/hashCode por valor")
+    void basics() {
+        JwtTokenDTO a = new JwtTokenDTO("jwt-token");
+        JwtTokenDTO b = new JwtTokenDTO("jwt-token");
+
+        assertThat(a.token()).isEqualTo("jwt-token");
+        assertThat(a).isEqualTo(b);
+        assertThat(a).hasSameHashCodeAs(b);
+        assertThat(a.toString()).contains("jwt-token");
+    }
+
+}

--- a/domain/model/src/test/java/co/com/pragma/model/user/dto/response/UserPrincipalDTOTest.java
+++ b/domain/model/src/test/java/co/com/pragma/model/user/dto/response/UserPrincipalDTOTest.java
@@ -1,0 +1,36 @@
+package co.com.pragma.model.user.dto.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserPrincipalDTOTest {
+
+    @Test
+    @DisplayName("@Builder crea y toBuilder permite modificar")
+    void builderAndToBuilder() {
+        UUID id = UUID.randomUUID();
+
+        UserPrincipalDTO principal = UserPrincipalDTO.builder()
+                .userId(id)
+                .email("user@mail.com")
+                .password("encoded")
+                .roles("ROLE_USER")
+                .build();
+
+        assertThat(principal.userId()).isEqualTo(id);
+        assertThat(principal.email()).isEqualTo("user@mail.com");
+        assertThat(principal.password()).isEqualTo("encoded");
+        assertThat(principal.roles()).isEqualTo("ROLE_USER");
+
+        UserPrincipalDTO changed = principal.toBuilder().roles("ROLE_ADMIN").build();
+        assertThat(changed.roles()).isEqualTo("ROLE_ADMIN");
+        assertThat(changed.userId()).isEqualTo(principal.userId());
+        assertThat(changed.email()).isEqualTo(principal.email());
+        assertThat(changed).isNotSameAs(principal);
+    }
+
+}

--- a/domain/model/src/test/java/co/com/pragma/model/user/error/LoginErrorCodeTest.java
+++ b/domain/model/src/test/java/co/com/pragma/model/user/error/LoginErrorCodeTest.java
@@ -1,0 +1,30 @@
+package co.com.pragma.model.user.error;
+
+import co.com.pragma.model.shared.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoginErrorCodeTest {
+
+    @Test
+    @DisplayName("INVALID_CREDENTIALS expone metadatos correctos")
+    void metadata() {
+        LoginErrorCode code = LoginErrorCode.INVALID_CREDENTIALS;
+
+        assertThat(code.getAppCode()).isEqualTo("LGN_001");
+        assertThat(code.getHttpCode()).isEqualTo(401);
+        assertThat(code.getMessage()).isEqualTo("Invalid username or password.");
+    }
+
+    @Test
+    @DisplayName("values() y valueOf() funcionan; implementa ErrorCode")
+    void valuesAndInterface() {
+        assertThat(LoginErrorCode.values()).hasSize(1);
+        assertThat(LoginErrorCode.valueOf("INVALID_CREDENTIALS"))
+                .isSameAs(LoginErrorCode.INVALID_CREDENTIALS);
+        assertThat(LoginErrorCode.INVALID_CREDENTIALS).isInstanceOf(ErrorCode.class);
+    }
+
+}

--- a/domain/model/src/test/java/co/com/pragma/model/user/error/UserErrorCodeTest.java
+++ b/domain/model/src/test/java/co/com/pragma/model/user/error/UserErrorCodeTest.java
@@ -1,9 +1,14 @@
 package co.com.pragma.model.user.error;
 
+import co.com.pragma.model.shared.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.text.MessageFormat;
+import java.util.EnumMap;
+import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -11,21 +16,73 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 class UserErrorCodeTest {
 
     @Test
-    @DisplayName("Should format messages with placeholders")
-    void all_have_values() {
-        for (UserErrorCode code : UserErrorCode.values()) {
-            assertThat(code.getAppCode()).isNotBlank();
-            assertThat(code.getHttpCode()).isBetween(100, 599);
-            assertThat(code.getMessage()).isNotBlank();
+    @DisplayName("Each constant present appCode, httpCode and message well")
+    void metadataByConstant() {
+        Map<UserErrorCode, String> appCodes = new EnumMap<>(UserErrorCode.class);
+        appCodes.put(UserErrorCode.REQUIRED_FIRSTNAME, "USR_001");
+        appCodes.put(UserErrorCode.REQUIRED_LASTNAME, "USR_002");
+        appCodes.put(UserErrorCode.REQUIRED_EMAIL, "USR_003");
+        appCodes.put(UserErrorCode.REQUIRED_SALARY, "USR_004");
+        appCodes.put(UserErrorCode.INVALID_EMAIL, "USR_005");
+        appCodes.put(UserErrorCode.INVALID_SALARY, "USR_006");
+        appCodes.put(UserErrorCode.EMAIL_IN_USE, "USR_007");
+        appCodes.put(UserErrorCode.USER_NOT_FOUND, "USR_008");
+        appCodes.put(UserErrorCode.USER_NOT_FOUND_BY_EMAIL, "USR_008");
+
+        Map<UserErrorCode, Integer> httpCodes = new EnumMap<>(UserErrorCode.class);
+        httpCodes.put(UserErrorCode.REQUIRED_FIRSTNAME, 400);
+        httpCodes.put(UserErrorCode.REQUIRED_LASTNAME, 400);
+        httpCodes.put(UserErrorCode.REQUIRED_EMAIL, 400);
+        httpCodes.put(UserErrorCode.REQUIRED_SALARY, 400);
+        httpCodes.put(UserErrorCode.INVALID_EMAIL, 400);
+        httpCodes.put(UserErrorCode.INVALID_SALARY, 400);
+        httpCodes.put(UserErrorCode.EMAIL_IN_USE, 409);
+        httpCodes.put(UserErrorCode.USER_NOT_FOUND, 404);
+        httpCodes.put(UserErrorCode.USER_NOT_FOUND_BY_EMAIL, 404);
+
+        Map<UserErrorCode, String> messages = new EnumMap<>(UserErrorCode.class);
+        messages.put(UserErrorCode.REQUIRED_FIRSTNAME, "Firstname is required.");
+        messages.put(UserErrorCode.REQUIRED_LASTNAME, "Lastname is required.");
+        messages.put(UserErrorCode.REQUIRED_EMAIL, "Email is required.");
+        messages.put(UserErrorCode.REQUIRED_SALARY, "Base salary is required.");
+        messages.put(UserErrorCode.INVALID_EMAIL, "Invalid email format: {0}");
+        messages.put(UserErrorCode.INVALID_SALARY, "Base salary must be between 0 and 15000000.");
+        messages.put(UserErrorCode.EMAIL_IN_USE, "Email ''{0}'' is already in use.");
+        messages.put(UserErrorCode.USER_NOT_FOUND, "User not found with id {0}");
+        messages.put(UserErrorCode.USER_NOT_FOUND_BY_EMAIL, "User not found with email {0}");
+
+        for (UserErrorCode c : UserErrorCode.values()) {
+            assertThat(c.getAppCode()).isEqualTo(appCodes.get(c));
+            assertThat(c.getHttpCode()).isEqualTo(httpCodes.get(c));
+            assertThat(c.getMessage()).isEqualTo(messages.get(c));
+            assertThat(c).isInstanceOf(ErrorCode.class);
         }
     }
 
     @Test
-    @DisplayName("EMAIL_IN_USE should wrap the value with single quotes (MessageFormat)")
-    void specific_values() {
-        assertThat(UserErrorCode.REQUIRED_FIRSTNAME.getAppCode()).isEqualTo("USR_001");
-        assertThat(UserErrorCode.USER_NOT_FOUND.getHttpCode()).isEqualTo(404);
-        assertThat(UserErrorCode.INVALID_SALARY.getMessage()).contains("between 0 and 15000000");
+    @DisplayName("Message formating with {0} (MessageFormat)")
+    void messageFormatting() {
+        assertThat(MessageFormat.format(UserErrorCode.INVALID_EMAIL.getMessage(), "bad@mail"))
+                .isEqualTo("Invalid email format: bad@mail");
+
+        assertThat(MessageFormat.format(UserErrorCode.EMAIL_IN_USE.getMessage(), "john@mail.com"))
+                .isEqualTo("Email 'john@mail.com' is already in use.");
+
+        assertThat(MessageFormat.format(UserErrorCode.USER_NOT_FOUND.getMessage(), "123"))
+                .isEqualTo("User not found with id 123");
+
+        assertThat(MessageFormat.format(UserErrorCode.USER_NOT_FOUND_BY_EMAIL.getMessage(), "john@mail.com"))
+                .isEqualTo("User not found with email john@mail.com");
+    }
+
+    @Test
+    @DisplayName("values() contains the nine constants and valueOf() works")
+    void valuesAndValueOf() {
+        assertThat(UserErrorCode.values()).hasSize(9);
+        assertThat(UserErrorCode.valueOf("REQUIRED_FIRSTNAME"))
+                .isSameAs(UserErrorCode.REQUIRED_FIRSTNAME);
+        assertThat(UserErrorCode.valueOf("USER_NOT_FOUND_BY_EMAIL"))
+                .isSameAs(UserErrorCode.USER_NOT_FOUND_BY_EMAIL);
     }
 
 }

--- a/domain/usecase/src/test/java/co/com/pragma/usecase/auth/AuthUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/usecase/auth/AuthUseCaseTest.java
@@ -1,0 +1,239 @@
+package co.com.pragma.usecase.auth;
+
+import co.com.pragma.model.role.Role;
+import co.com.pragma.model.role.gateways.RoleRepository;
+import co.com.pragma.model.shared.gateway.AuthGateway;
+import co.com.pragma.model.shared.gateway.TransactionalGateway;
+import co.com.pragma.model.user.User;
+import co.com.pragma.model.user.dto.request.LoginModelDTO;
+import co.com.pragma.model.user.dto.response.JwtTokenDTO;
+import co.com.pragma.model.user.dto.response.UserPrincipalDTO;
+import co.com.pragma.model.user.gateways.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+class AuthUseCaseTest {
+
+    @Mock
+    private TransactionalGateway transactionalGateway;
+    @Mock
+    private AuthGateway authGateway;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private RoleRepository roleRepository;
+
+    @InjectMocks
+    private AuthUseCase useCase;
+
+    // Utility: make TransactionalGateway return the inner Mono unchanged
+    private void stubTransactionPassthrough() {
+        when(transactionalGateway.execute(any(Mono.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("login(): success -> emits JwtTokenDTO and completes")
+    void login_success() {
+        // Arrange
+        stubTransactionPassthrough();
+
+        String email = "user@mail.com";
+        String rawPassword = "raw";
+        String storedPassword = "encoded";
+
+        UUID userId = UUID.randomUUID();
+        UUID roleId = UUID.randomUUID();
+
+        User user = User.builder()
+                .userId(userId)
+                .email(email)
+                .password(storedPassword)
+                .roleId(roleId)
+                .build();
+
+        Role role = Role.builder()
+                .roleId(roleId)
+                .name("ADMIN")
+                .description("desc")
+                .build();
+
+        when(userRepository.getByEmail(email)).thenReturn(Mono.just(user));
+        when(roleRepository.getRoleById(roleId)).thenReturn(Mono.just(role));
+        when(authGateway.isPasswordMatch(rawPassword, storedPassword)).thenReturn(true);
+
+        ArgumentCaptor<UserPrincipalDTO> principalCaptor = ArgumentCaptor.forClass(UserPrincipalDTO.class);
+        when(authGateway.generateToken(any(UserPrincipalDTO.class)))
+                .thenReturn(Mono.just(new JwtTokenDTO("jwt-token")));
+
+        // Act
+        Mono<JwtTokenDTO> result = useCase.login(new LoginModelDTO(email, rawPassword));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNextMatches(jwt -> "jwt-token".equals(jwt.token()))
+                .verifyComplete();
+
+        verify(userRepository, times(1)).getByEmail(email);
+        verify(roleRepository, times(1)).getRoleById(roleId);
+        verify(authGateway, times(1)).isPasswordMatch(rawPassword, storedPassword);
+        verify(authGateway, times(1)).generateToken(principalCaptor.capture());
+        verify(transactionalGateway, times(1)).execute(Mockito.<Mono<JwtTokenDTO>>any());
+
+        UserPrincipalDTO captured = principalCaptor.getValue();
+        assertThat(captured.email()).isEqualTo(email);
+        assertThat(captured.userId()).isEqualTo(userId);
+        assertThat(captured.password()).isEqualTo(storedPassword);
+        assertThat(captured.roles()).isEqualTo("ADMIN");
+    }
+
+    @Test
+    @DisplayName("login(): user not found -> propagates error (INVALID_CREDENTIALS)")
+    void login_userNotFound() {
+        // Arrange
+        stubTransactionPassthrough();
+
+        String email = "absent@mail.com";
+        String rawPassword = "x";
+
+        when(userRepository.getByEmail(email)).thenReturn(Mono.empty());
+
+        // Act
+        Mono<JwtTokenDTO> result = useCase.login(new LoginModelDTO(email, rawPassword));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> assertThat(throwable).isNotNull())
+                .verify();
+
+        verify(userRepository, times(1)).getByEmail(email);
+        verifyNoInteractions(roleRepository);
+        verify(authGateway, never()).isPasswordMatch(anyString(), anyString());
+        verify(authGateway, never()).generateToken(any());
+        verify(transactionalGateway, times(1)).execute(any(Mono.class));
+    }
+
+    @Test
+    @DisplayName("login(): wrong password -> propagates error (INVALID_CREDENTIALS)")
+    void login_wrongPassword() {
+        // Arrange
+        stubTransactionPassthrough();
+
+        String email = "user@mail.com";
+        String rawPassword = "wrong";
+        String storedPassword = "encoded";
+
+        UUID roleId = UUID.randomUUID();
+        User user = User.builder()
+                .email(email)
+                .password(storedPassword)
+                .roleId(roleId)
+                .build();
+
+        when(userRepository.getByEmail(email)).thenReturn(Mono.just(user));
+        when(roleRepository.getRoleById(roleId)).thenReturn(Mono.just(Role.builder()
+                .roleId(roleId).name("USER").description("desc").build()));
+        when(authGateway.isPasswordMatch(rawPassword, storedPassword)).thenReturn(false);
+
+        // Act
+        Mono<JwtTokenDTO> result = useCase.login(new LoginModelDTO(email, rawPassword));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> assertThat(throwable).isNotNull())
+                .verify();
+
+        verify(userRepository, times(1)).getByEmail(email);
+        verify(roleRepository, times(1)).getRoleById(roleId);
+        verify(authGateway, times(1)).isPasswordMatch(rawPassword, storedPassword);
+        verify(authGateway, never()).generateToken(any());
+        verify(transactionalGateway, times(1)).execute(any(Mono.class));
+    }
+
+    @Test
+    @DisplayName("login(): token generation fails -> emits error from AuthGateway")
+    void login_tokenGenerationFails() {
+        // Arrange
+        stubTransactionPassthrough();
+
+        String email = "user@mail.com";
+        String rawPassword = "ok";
+        String storedPassword = "encoded";
+        UUID roleId = UUID.randomUUID();
+
+        User user = User.builder()
+                .email(email)
+                .password(storedPassword)
+                .roleId(roleId)
+                .build();
+
+        when(userRepository.getByEmail(email)).thenReturn(Mono.just(user));
+        when(roleRepository.getRoleById(roleId)).thenReturn(Mono.just(Role.builder()
+                .roleId(roleId).name("USER").description("desc").build()));
+        when(authGateway.isPasswordMatch(rawPassword, storedPassword)).thenReturn(true);
+        when(authGateway.generateToken(any(UserPrincipalDTO.class)))
+                .thenReturn(Mono.error(new IllegalStateException("token failure")));
+
+        // Act
+        Mono<JwtTokenDTO> result = useCase.login(new LoginModelDTO(email, rawPassword));
+
+        // Assert
+        StepVerifier.create(result)
+                .expectErrorMatches(err -> err instanceof IllegalStateException
+                        && "token failure".equals(err.getMessage()))
+                .verify();
+
+        verify(userRepository, times(1)).getByEmail(email);
+        verify(roleRepository, times(1)).getRoleById(roleId);
+        verify(authGateway, times(1)).isPasswordMatch(rawPassword, storedPassword);
+        verify(authGateway, times(1)).generateToken(any(UserPrincipalDTO.class));
+        verify(transactionalGateway, times(1)).execute(any(Mono.class));
+    }
+
+    @Test
+    @DisplayName("buildUserPrincipalFromUser(): maps fields and role correctly")
+    void buildUserPrincipalFromUser_mapsCorrectly() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        UUID roleId = UUID.randomUUID();
+
+        User user = User.builder()
+                .userId(userId)
+                .email("user@mail.com")
+                .password("encoded")
+                .roleId(roleId)
+                .build();
+
+        when(roleRepository.getRoleById(roleId))
+                .thenReturn(Mono.just(Role.builder().roleId(roleId).name("MANAGER").description("d").build()));
+
+        // Act
+        Mono<UserPrincipalDTO> mono = useCase.buildUserPrincipalFromUser(user);
+
+        // Assert
+        StepVerifier.create(mono)
+                .assertNext(up -> {
+                    assertThat(up.userId()).isEqualTo(userId);
+                    assertThat(up.email()).isEqualTo("user@mail.com");
+                    assertThat(up.password()).isEqualTo("encoded");
+                    assertThat(up.roles()).isEqualTo("MANAGER");
+                })
+                .verifyComplete();
+
+        verify(roleRepository, times(1)).getRoleById(roleId);
+    }
+}

--- a/domain/usecase/src/test/java/co/com/pragma/usecase/usercrud/util/UserCreator.java
+++ b/domain/usecase/src/test/java/co/com/pragma/usecase/usercrud/util/UserCreator.java
@@ -15,7 +15,8 @@ public class UserCreator {
                 "123",
                 "555-1234",
                 5_000_000d,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 
@@ -28,7 +29,8 @@ public class UserCreator {
                 "123",
                 "555-1234",
                 5_000_000d,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 
@@ -41,7 +43,8 @@ public class UserCreator {
                 "123",
                 "555-1234",
                 5_000_000d,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 
@@ -54,7 +57,8 @@ public class UserCreator {
                 "123",
                 "555-1234",
                 5_000_000d,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 
@@ -67,7 +71,8 @@ public class UserCreator {
                 "123",
                 "555-1234",
                 5_000_000d,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 
@@ -80,7 +85,8 @@ public class UserCreator {
                 "123",
                 "555-1234",
                 null,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 
@@ -93,7 +99,8 @@ public class UserCreator {
                 "123",
                 "555-1234",
                 -1000d,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 
@@ -106,7 +113,8 @@ public class UserCreator {
                 "123",
                 "555-1234",
                 20_000_000d,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 
@@ -119,7 +127,8 @@ public class UserCreator {
                 "123",
                 "555-1234",
                 5_000_000d,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 
@@ -128,11 +137,12 @@ public class UserCreator {
                 null,
                 "  Juan  ",
                 "  Perez  ",
-                "TEST@MAIL.COM",  // válido, pasa regex
+                "TEST@MAIL.COM",
                 "   123   ",
                 "   555-1234   ",
                 3_000_000d,
-                "password"
+                "password",
+                UUID.randomUUID()
         );
     }
 


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the domain model's `role` and `user` classes, their associated error codes, and DTOs. The new tests verify constructors, builder patterns, equality, and error code metadata, improving coverage and reliability for core domain entities and error handling.

### Domain Model Entity Tests

* Added `RoleTest` to cover builder, setters/getters, cloning via `toBuilder`, equality/hashCode, and `toString` for the `Role` entity.
* Expanded `UserTest` to include new fields (`password`, `roleId`), verify all constructors, and test equality/hashCode with these fields. [[1]](diffhunk://#diff-b89ea337845702f3932f9f7e7d30092ed322b613f25ff5b3676cae017c8fbcffL10-R17) [[2]](diffhunk://#diff-b89ea337845702f3932f9f7e7d30092ed322b613f25ff5b3676cae017c8fbcffR26-R27) [[3]](diffhunk://#diff-b89ea337845702f3932f9f7e7d30092ed322b613f25ff5b3676cae017c8fbcffR36-R49) [[4]](diffhunk://#diff-b89ea337845702f3932f9f7e7d30092ed322b613f25ff5b3676cae017c8fbcffR58-R81) [[5]](diffhunk://#diff-b89ea337845702f3932f9f7e7d30092ed322b613f25ff5b3676cae017c8fbcffL73)

### DTO Tests

* Added `LoginModelDTOTest` to verify record field access, equality, hashCode, and `toString` for login DTO.
* Added `JwtTokenDTOTest` to verify record field access, equality, hashCode, and `toString` for JWT token DTO.
* Added `UserPrincipalDTOTest` to test builder, `toBuilder`, and field access for user principal DTO.

### Error Code Tests

* Added `RoleErrorCodeTest` to verify error code metadata, message formatting, enum methods, and interface implementation.
* Added `LoginErrorCodeTest` to verify error code metadata, enum methods, and interface implementation for login errors.
* Refactored and expanded `UserErrorCodeTest` to explicitly validate each constant's metadata, message formatting, and enum methods.